### PR TITLE
config struct plus unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
+
+[[package]]
 name = "arc-swap"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +559,7 @@ dependencies = [
 name = "monitorbot"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "dotenv",
  "futures",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ tokio = { version = "0.2", features = ["full"] }
 hyper = "0.13"
 prometheus = "0.10"
 futures = "0.3"
+anyhow = "1.0"

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -3,11 +3,10 @@ pub use crate::collectors::github_rate_limit::GitHubRateLimit;
 
 use crate::MetricProvider;
 use futures::FutureExt;
-use std::borrow::Borrow;
 
 // register collectors for metrics gathering
 pub async fn register_collectors(p: &MetricProvider) -> Result<(), prometheus::Error> {
-    GitHubRateLimit::new(p.config.borrow())
+    GitHubRateLimit::new(&p.config)
         .map(|rl| p.register_collector(rl))
         .await
 }

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -3,10 +3,11 @@ pub use crate::collectors::github_rate_limit::GitHubRateLimit;
 
 use crate::MetricProvider;
 use futures::FutureExt;
+use std::borrow::Borrow;
 
 // register collectors for metrics gathering
 pub async fn register_collectors(p: &MetricProvider) -> Result<(), prometheus::Error> {
-    GitHubRateLimit::new()
+    GitHubRateLimit::new(p.config.borrow())
         .map(|rl| p.register_collector(rl))
         .await
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,10 +20,7 @@ impl Config {
         Ok(Self {
             port: default_env("PORT", 3001)?,
             gh_rate_limit_tokens: require_env("RATE_LIMIT_TOKENS")?,
-            gh_rate_limit_stats_cache_refresh: default_env(
-                "GH_RATE_LIMIT_STATS_REFRESH",
-                120,
-            )?,
+            gh_rate_limit_stats_cache_refresh: default_env("GH_RATE_LIMIT_STATS_REFRESH", 120)?,
         })
     }
 }
@@ -73,8 +70,8 @@ mod tests {
     // you need to use a unique env var name for your test. cargo by default will run
     // your tests in parallel using threads and one test setup may interfere with
     // another test's outcome if they both share the same env var name.
-    use super::{maybe_env, default_env, require_env};
     use super::ENVIRONMENT_VARIABLE_PREFIX;
+    use super::{default_env, maybe_env, require_env};
 
     #[test]
     fn config_some_value_not_present() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,6 +69,10 @@ impl Error for ConfigError {}
 
 #[cfg(test)]
 mod tests {
+    // note: if you add new unit tests here and need to set up an env var
+    // you need to use a unique env var name for your test. cargo by default will run
+    // your tests in parallel using threads and one test setup may interfere with
+    // another test's outcome if they both share the same env var name.
     use super::Config;
     use super::ENVIRONMENT_VARIABLE_PREFIX;
 
@@ -87,10 +91,10 @@ mod tests {
     fn config_some_value_string_present() {
         let expected: String = String::from("12345678");
         std::env::set_var(
-            format!("{}TEST_VAR", ENVIRONMENT_VARIABLE_PREFIX),
+            format!("{}TEST_VAR_STR", ENVIRONMENT_VARIABLE_PREFIX),
             &expected,
         );
-        let result = match Config::maybe_env("TEST_VAR") {
+        let result = match Config::maybe_env("TEST_VAR_STR") {
             Ok(r) => r,
             Err(_) => panic!("return value as Err, we expected Option"), // we failed
         };
@@ -116,7 +120,7 @@ mod tests {
     #[test]
     fn config_default_value_u16_not_present() {
         let expected = 3001u16;
-        let result = match Config::default_env::<u16>("PORT", expected) {
+        let result = match Config::default_env::<u16>("PORT_NOT_SET", expected) {
             Ok(r) => r,
             Err(_) => panic!("return value as Err, we expected Option"), // we failed
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,178 @@
+use std::env::VarError;
+use std::error::Error;
+use std::fmt;
+use std::str::FromStr;
+
+const ENVIRONMENT_VARIABLE_PREFIX: &str = "MONITORBOT_";
+
+#[derive(Clone, Debug)]
+pub struct Config {
+    // http server port to bind to
+    pub port: u16,
+    // github api tokens to collect rate limit statistics
+    pub gh_rate_limit_tokens: String,
+    // github rate limit stats data cache refresh rate frequency (in seconds)
+    pub gh_rate_limit_stats_cache_refresh: u64,
+}
+
+impl Config {
+    pub fn from_env() -> Result<Self, ConfigError> {
+        Ok(Self {
+            port: Self::default_env("PORT", 3001)?,
+            gh_rate_limit_tokens: Self::require_env("RATE_LIMIT_TOKENS")?,
+            gh_rate_limit_stats_cache_refresh: Self::default_env::<u64>(
+                "GH_RATE_LIMIT_STATS_REFRESH",
+                120u64,
+            )?,
+        })
+    }
+
+    fn maybe_env<T: FromStr>(name: &str) -> Result<Option<T>, ConfigError> {
+        match std::env::var(format!("{}{}", ENVIRONMENT_VARIABLE_PREFIX, name)) {
+            Ok(val) => match val.parse() {
+                Ok(v) => Ok(Some(v)),
+                _ => Err(ConfigError(format!(
+                    "the {} environment variable has invalid content",
+                    name
+                ))),
+            },
+            Err(VarError::NotPresent) => Ok(None),
+            Err(not_unicode) => Err(ConfigError(format!("the {} {}", name, not_unicode))),
+        }
+    }
+
+    fn require_env<T: FromStr>(name: &str) -> Result<T, ConfigError> {
+        match Self::maybe_env::<T>(name)? {
+            Some(res) => Ok(res),
+            None => Err(ConfigError(format!(
+                "missing environment variable {}{}",
+                ENVIRONMENT_VARIABLE_PREFIX, name
+            ))),
+        }
+    }
+
+    fn default_env<T: FromStr>(name: &str, default: T) -> Result<T, ConfigError> {
+        Ok(Self::maybe_env::<T>(name)?.unwrap_or(default))
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct ConfigError(String);
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Error for ConfigError {}
+
+#[cfg(test)]
+mod tests {
+    use super::Config;
+    use super::ENVIRONMENT_VARIABLE_PREFIX;
+
+    #[test]
+    fn config_some_value_not_present() {
+        let expected: Option<String> = None;
+        let result = match Config::maybe_env("NOT_EXISTENT") {
+            Ok(r) => r,
+            Err(_) => panic!("return value as Err, we expected Option"), // we failed
+        };
+
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn config_some_value_string_present() {
+        let expected: String = String::from("12345678");
+        std::env::set_var(
+            format!("{}TEST_VAR", ENVIRONMENT_VARIABLE_PREFIX),
+            &expected,
+        );
+        let result = match Config::maybe_env("TEST_VAR") {
+            Ok(r) => r,
+            Err(_) => panic!("return value as Err, we expected Option"), // we failed
+        };
+
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn config_some_value_u16_present() {
+        let expected = 12345u16;
+        std::env::set_var(
+            format!("{}TEST_VAR", ENVIRONMENT_VARIABLE_PREFIX),
+            expected.to_string(),
+        );
+        let result = match Config::maybe_env::<u16>("TEST_VAR") {
+            Ok(r) => r,
+            Err(_) => panic!("return value as Err, we expected Option"), // we failed
+        };
+
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn config_default_value_u16_not_present() {
+        let expected = 3001u16;
+        let result = match Config::default_env::<u16>("PORT", expected) {
+            Ok(r) => r,
+            Err(_) => panic!("return value as Err, we expected Option"), // we failed
+        };
+
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn config_default_value_u16_present() {
+        let expected = 80u16;
+        std::env::set_var(
+            format!("{}PORT", ENVIRONMENT_VARIABLE_PREFIX),
+            expected.to_string(),
+        );
+
+        let result = match Config::default_env::<u16>("PORT", 3001u16) {
+            Ok(r) => r,
+            Err(_) => panic!("return value as Err, we expected Option"), // we failed
+        };
+
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn config_require_string_present() {
+        let expected = "TOKENS,TOKENS,TOKENS".to_string();
+        std::env::set_var(
+            format!("{}RATE_LIMIT_TOKENS", ENVIRONMENT_VARIABLE_PREFIX),
+            expected.to_string(),
+        );
+
+        let result = match Config::require_env::<String>("RATE_LIMIT_TOKENS") {
+            Ok(r) => r,
+            Err(_) => panic!("return value as Err, we expected Option"), // we failed
+        };
+
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn config_require_string_not_present() {
+        use super::ConfigError;
+
+        let env_var = format!("{}TOKENS_NOT_PRESENT", ENVIRONMENT_VARIABLE_PREFIX);
+        match Config::require_env::<String>("TOKENS_NOT_PRESENT") {
+            Ok(r) => r,
+            Err(e) => {
+                assert_eq!(
+                    ConfigError(format!("missing environment variable {}", env_var)),
+                    e
+                );
+                return;
+            }
+        };
+
+        // we failed if our code gets here
+        panic!("return value as Err, we expected Option");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::new_without_default)]
 
 pub mod collectors;
+mod config;
+pub use config::Config;
 
 use prometheus::core::Collector;
 use prometheus::{Encoder, Registry};
@@ -13,12 +15,13 @@ use hyper::{Body, Method, Request, Response, StatusCode};
 #[derive(Clone, Debug)]
 pub struct MetricProvider {
     register: prometheus::Registry,
+    config: Config,
 }
 
 impl MetricProvider {
-    pub fn new() -> Self {
+    pub fn new(config: Config) -> Self {
         let register = Registry::new_custom(None, None).expect("Unable to build Registry");
-        Self { register }
+        Self { register, config }
     }
 
     fn register_collector(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,17 @@
 use hyper::Server;
+use monitorbot::Config;
 use monitorbot::{collectors::register_collectors, MetricProvider};
 use std::net::SocketAddr;
-use std::str::FromStr;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenv::dotenv().ok();
 
-    let port = std::env::var("MONITORBOT_PORT").unwrap_or_else(|_| "3001".to_string());
-    let addr = match u16::from_str(port.as_ref()) {
-        Ok(port) => SocketAddr::from(([0, 0, 0, 0], port)),
-        Err(e) => {
-            eprintln!("Unable to parse MONITOR PORT: {:?}", e);
-            return Ok(());
-        }
-    };
+    let config = Config::from_env()?;
+    let port = config.port;
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
 
-    let provider = MetricProvider::new();
+    let provider = MetricProvider::new(config);
     if let Err(e) = register_collectors(&provider).await {
         eprintln!("Unable to register collectors: {:#?}", e);
         return Ok(());


### PR DESCRIPTION
This PR adds the global env Config struct according to suggested in #4.

- It's basically a copy/paste from the struct present in promote release with a minor refactor. (removed anyhow crate dependency for now cos I don't know if we want to use it in this bot or any other error crate)
- Introduced own ConfigError struct for errors related with initialization and parsing of env vars for the Config struct.
- Also didn't add the `bool_env()` helper method since we currently don't have the need for it.

And since @pietroalbini added GHA ci magic, I've also added some initial unit test.

?r @pietroalbini 