### PR TITLE
tiny change towards better error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +124,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a51b8cf747471cb9499b6d59e59b0444f4c90eba8968c4e44874e92b5b64ace2"
 dependencies = [
  "cfg-if 0.1.10",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54532e3223c5af90a6a757c90b5c5521564b07e5e7a958681bcd2afad421cdcd"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -325,6 +349,12 @@ name = "httpdate"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+
+[[package]]
+name = "humantime"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "hyper"
@@ -561,8 +591,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "dotenv",
+ "env_logger",
  "futures",
  "hyper",
+ "log",
  "prometheus",
  "reqwest",
  "serde",
@@ -1053,6 +1085,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1366,6 +1407,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,5 @@ hyper = "0.13"
 prometheus = "0.10"
 futures = "0.3"
 anyhow = "1.0"
+log = "0.4"
+env_logger = { version = "0.8", features = ["termcolor", "humantime"] }

--- a/src/collectors/github_rate_limit.rs
+++ b/src/collectors/github_rate_limit.rs
@@ -132,16 +132,8 @@ impl GitHubRateLimit {
         }
 
         let client = reqwest::Client::new();
-        let req = GithubReqBuilder::User
-            .build_request(&client, &token)
-            .unwrap();
-        let u = client
-            .execute(req)
-            .await
-            .map_err(Error::from)?
-            .json::<GithubUser>()
-            .await
-            .map_err(Error::from)?;
+        let req = GithubReqBuilder::User.build_request(&client, &token)?;
+        let u = client.execute(req).await?.json::<GithubUser>().await?;
 
         Ok(u.login)
     }

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -3,14 +3,14 @@ mod github_rate_limit;
 pub use crate::collectors::github_rate_limit::GitHubRateLimit;
 
 use crate::MetricProvider;
-use anyhow::Result;
-use futures::FutureExt;
+use anyhow::{Error, Result};
+use futures::TryFutureExt;
 use log::info;
 
 // register collectors for metrics gathering
-pub async fn register_collectors(p: &MetricProvider) -> Result<()> {
+pub async fn register_collectors(p: &MetricProvider) -> Result<(), Error> {
     GitHubRateLimit::new(&p.config)
-        .map(|rl| {
+        .and_then(|rl| async {
             info!("Registering GitHubRateLimit collector");
             p.register_collector(rl)
         })

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -1,12 +1,18 @@
 mod github_rate_limit;
+
 pub use crate::collectors::github_rate_limit::GitHubRateLimit;
 
 use crate::MetricProvider;
+use anyhow::Result;
 use futures::FutureExt;
+use log::info;
 
 // register collectors for metrics gathering
-pub async fn register_collectors(p: &MetricProvider) -> Result<(), prometheus::Error> {
+pub async fn register_collectors(p: &MetricProvider) -> Result<()> {
     GitHubRateLimit::new(&p.config)
-        .map(|rl| p.register_collector(rl))
+        .map(|rl| {
+            info!("Registering GitHubRateLimit collector");
+            p.register_collector(rl)
+        })
         .await
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,13 +27,13 @@ impl MetricProvider {
         Self { register, config }
     }
 
-    fn register_collector(&self, collector: impl Collector + 'static) -> Result<()> {
+    fn register_collector(&self, collector: impl Collector + 'static) -> Result<(), Error> {
         self.register
             .register(Box::new(collector))
             .map_err(Error::from)
     }
 
-    fn gather_with_encoder<BUF>(&self, encoder: impl Encoder, buf: &mut BUF) -> Result<()>
+    fn gather_with_encoder<BUF>(&self, encoder: impl Encoder, buf: &mut BUF) -> Result<(), Error>
     where
         BUF: std::io::Write,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,15 +2,18 @@
 
 pub mod collectors;
 mod config;
+
 pub use config::Config;
 
 use prometheus::core::Collector;
 use prometheus::{Encoder, Registry};
 
+use anyhow::{Error, Result};
 use futures::future;
 use futures::task::{Context, Poll};
 use hyper::service::Service;
 use hyper::{Body, Method, Request, Response, StatusCode};
+use log::{debug, error};
 
 #[derive(Clone, Debug)]
 pub struct MetricProvider {
@@ -24,15 +27,19 @@ impl MetricProvider {
         Self { register, config }
     }
 
-    fn register_collector(
-        &self,
-        collector: impl Collector + 'static,
-    ) -> Result<(), prometheus::Error> {
-        self.register.register(Box::new(collector))
+    fn register_collector(&self, collector: impl Collector + 'static) -> Result<()> {
+        self.register
+            .register(Box::new(collector))
+            .map_err(Error::from)
     }
 
-    fn gather_with_encoder<BUF: std::io::Write>(&self, encoder: impl Encoder, buf: &mut BUF) {
-        encoder.encode(&self.register.gather(), buf).unwrap();
+    fn gather_with_encoder<BUF>(&self, encoder: impl Encoder, buf: &mut BUF) -> Result<()>
+    where
+        BUF: std::io::Write,
+    {
+        encoder
+            .encode(&self.register.gather(), buf)
+            .map_err(Error::from)
     }
 
     pub fn into_service(self) -> MetricProviderFactory {
@@ -50,17 +57,26 @@ impl Service<Request<Body>> for MetricProvider {
     }
 
     fn call(&mut self, req: Request<Body>) -> Self::Future {
+        debug!("New Request to endpoint {}", req.uri().path());
+
         let output = match (req.method(), req.uri().path()) {
             // Metrics handler
             (&Method::GET, "/metrics") => {
                 let encoder = prometheus::TextEncoder::new();
                 let mut buffer = Vec::<u8>::new();
-                self.gather_with_encoder(encoder, &mut buffer);
-
-                Response::builder()
-                    .status(StatusCode::OK)
-                    .body(Body::from(buffer))
-                    .unwrap()
+                match self.gather_with_encoder(encoder, &mut buffer) {
+                    Ok(_) => Response::builder()
+                        .status(StatusCode::OK)
+                        .body(Body::from(buffer))
+                        .unwrap(),
+                    Err(e) => {
+                        error!("{:?}", e);
+                        Response::builder()
+                            .status(StatusCode::INTERNAL_SERVER_ERROR)
+                            .body(Body::empty())
+                            .unwrap()
+                    }
+                }
             }
             // All other paths and methods
             _ => Response::builder()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Error, Result};
 use hyper::Server;
 use log::info;
 use monitorbot::Config;
@@ -6,7 +6,7 @@ use monitorbot::{collectors::register_collectors, MetricProvider};
 use std::net::SocketAddr;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Error> {
     dotenv::dotenv().ok();
     env_logger::init();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,14 @@
+use anyhow::{bail, Result};
 use hyper::Server;
+use log::info;
 use monitorbot::Config;
 use monitorbot::{collectors::register_collectors, MetricProvider};
 use std::net::SocketAddr;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<()> {
     dotenv::dotenv().ok();
+    env_logger::init();
 
     let config = Config::from_env()?;
     let port = config.port;
@@ -13,15 +16,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let provider = MetricProvider::new(config);
     if let Err(e) = register_collectors(&provider).await {
-        eprintln!("Unable to register collectors: {:#?}", e);
-        return Ok(());
+        bail!("(Registering collectors) {}", e)
     }
 
     let server = Server::bind(&addr).serve(provider.into_service());
-    println!("Server listening on port {}", port);
+    info!("Server listening on port: {}", port);
 
     if let Err(e) = server.await {
-        eprintln!("Server error: {}", e);
+        bail!("(Hyper server error) {}", e);
     }
 
     Ok(())


### PR DESCRIPTION
This PR is a small initial refactorization for better error handling.

- included `log` and `env_logger` crates and added some console messages.
- uniformed functions and methods that returns `Result<T, E>` with a wide range of `E`s into `anyhow::Error` since we already have that crate in the app.
- refactor some `unwrap()` calls that could make the application panic (mainly on the gh api requests section) to better cope with eventual errors and not letting the app abort because of spurious errors.
- plus one or two minor changes (mainly cosmetics)

