### PR TITLE
inject http client to rate limit collector and house keeping

### DIFF
--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -5,11 +5,11 @@ pub use crate::collectors::github_rate_limit::GitHubRateLimit;
 pub use crate::collectors::github_runners::GithubRunners;
 
 use crate::MetricProvider;
-use anyhow::{Error, Result};
+use anyhow::{Context, Error, Result};
 use futures::TryFutureExt;
 use log::info;
 use reqwest::header::{HeaderMap, ACCEPT, AUTHORIZATION};
-use reqwest::ClientBuilder;
+use reqwest::{ClientBuilder, Response};
 
 // register collectors for metrics gathering
 pub async fn register_collectors(p: &MetricProvider) -> Result<(), Error> {
@@ -17,7 +17,7 @@ pub async fn register_collectors(p: &MetricProvider) -> Result<(), Error> {
         .user_agent("https://github.com/rust-lang/monitorbot (infra@rust-lang.org)")
         .build()?;
 
-    GitHubRateLimit::new(&p.config)
+    GitHubRateLimit::new(&p.config, http.clone())
         .and_then(|rl| async {
             info!("Registering GitHubRateLimit collector");
             p.register_collector(rl)
@@ -40,4 +40,19 @@ fn default_headers(token: &str) -> HeaderMap {
     );
     headers.insert(ACCEPT, "application/vnd.github.v3+json".parse().unwrap());
     headers
+}
+
+fn guard_rate_limited(response: &Response) -> Result<&Response> {
+    let rate_limited = match response.headers().get("x-ratelimit-remaining") {
+        Some(rl) => rl.to_str()?.parse::<usize>()? == 0,
+        None => unreachable!(),
+    };
+
+    if rate_limited {
+        return response
+            .error_for_status_ref()
+            .context("We've hit the rate limit");
+    }
+
+    Ok(response)
 }


### PR DESCRIPTION
closed #18 

- Refactor Rate limit collector as described in #18 
- Injecting HTTP client in collector's constructor like in GH Action runners and suggested here https://github.com/rust-lang/monitorbot/pull/15#discussion_r619100453
- moved `default_headers()` function from `collectors::github_runners` to `collectors` module since that code is now used by both collectors.